### PR TITLE
feat: add search bar component

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 20.17.10
       '@worldcoin/minikit-js':
         specifier: 1.1.1
-        version: 1.1.1(@types/react@19.0.2)(react@18.3.1)(typescript@5.7.2)(viem@2.21.59(typescript@5.7.2))
+        version: 1.1.1(@types/react@19.0.2)(react@18.3.1)(typescript@5.7.2)(viem@2.21.60(typescript@5.7.2))
       dotenv:
         specifier: ^16.4.5
         version: 16.4.7
@@ -1823,8 +1823,8 @@ packages:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
 
-  viem@2.21.59:
-    resolution: {integrity: sha512-aHycB6LRxmUiKArOoQ1nYmhtVvZgU+ltAVvK7J1g+MuSbZZW5pXUtosRCBLlCO2gs05zYfrhVih+LmbRrdEXKg==}
+  viem@2.21.60:
+    resolution: {integrity: sha512-fzelL587wOtgNNKphbFCa/Ac9AgFGYKNdEZ04s5OO9Ua6Wu/3qIwjRmq3Z2rmiixr8HSqOHXjWLua6NiuUoRDg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -2187,7 +2187,7 @@ snapshots:
     dependencies:
       browser-or-node: 3.0.0-pre.0
       buffer: 6.0.3
-      viem: 2.21.59(typescript@5.7.2)
+      viem: 2.21.60(typescript@5.7.2)
       zustand: 4.5.5(@types/react@19.0.2)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
@@ -2198,11 +2198,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@worldcoin/minikit-js@1.1.1(@types/react@19.0.2)(react@18.3.1)(typescript@5.7.2)(viem@2.21.59(typescript@5.7.2))':
+  '@worldcoin/minikit-js@1.1.1(@types/react@19.0.2)(react@18.3.1)(typescript@5.7.2)(viem@2.21.60(typescript@5.7.2))':
     dependencies:
       '@worldcoin/idkit-core': 1.3.0(@types/react@19.0.2)(react@18.3.1)(typescript@5.7.2)
       abitype: 1.0.8(typescript@5.7.2)
-      viem: 2.21.59(typescript@5.7.2)
+      viem: 2.21.60(typescript@5.7.2)
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -3836,7 +3836,7 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  viem@2.21.59(typescript@5.7.2):
+  viem@2.21.60(typescript@5.7.2):
     dependencies:
       '@noble/curves': 1.7.0
       '@noble/hashes': 1.6.1

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { ProfileCard } from '@/components/ui/ProfileCard'
+import { ProfileCard } from '@/components/UI/ProfileCard'
+import SearchBar from '@/components/UI/Search-Bar'
 
 export default function Home() {
   return (
     <div className="flex min-h-screen items-center justify-center">
       <ProfileCard />
+      <SearchBar onSearch={(query) => console.log(query)} />
     </div>
   )
 }

--- a/frontend/src/components/ui/Search-Bar.tsx
+++ b/frontend/src/components/ui/Search-Bar.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { useState, ChangeEvent, KeyboardEvent, InputHTMLAttributes, forwardRef } from 'react'
+import { Search } from 'lucide-react'
+
+// Utility function for class names
+const cn = (...classes: (string | boolean | undefined)[]) => classes.filter(Boolean).join(' ')
+
+// Input component
+const Input = forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = "Input"
+
+interface SearchBarProps {
+  onSearch: (query: string) => void
+  className?: string
+  placeholder?: string
+}
+
+export default function SearchBar({ 
+  onSearch, 
+  className, 
+  placeholder = "Search for tests" 
+}: SearchBarProps) {
+  const [searchQuery, setSearchQuery] = useState('')
+
+  const handleSearch = () => {
+    onSearch(searchQuery)
+  }
+
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(e.target.value)
+  }
+
+  const handleKeyPress = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSearch()
+    }
+  }
+
+  return (
+    <div className={cn("relative w-full max-w-md", className)}>
+      <Input
+        type="search"
+        placeholder={placeholder}
+        value={searchQuery}
+        onChange={handleInputChange}
+        onKeyPress={handleKeyPress}
+        className="w-full h-12 pl-4 pr-12 bg-white rounded-full border-0 text-gray-600 placeholder:text-gray-400 focus-visible:ring-0 focus-visible:ring-offset-0"
+      />
+      <button
+        onClick={handleSearch}
+        className="absolute right-3 top-1/2 -translate-y-1/2 bg-[#1B4B43] p-2 rounded-full transition-colors hover:bg-[#15372F] focus:outline-none focus:ring-2 focus:ring-[#1B4B43] focus:ring-offset-2"
+        aria-label="Search"
+      >
+        <Search className="w-4 h-4 text-white" />
+      </button>
+    </div>
+  )
+}
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+} 


### PR DESCRIPTION
Closes #9 

This PR adds a reusable Search-Bar.tsx component for searching different tests through the miniapp with a responsive search button that displays all tests available depending on what the user wants to search. Also, it follows the Figma design with the colors and design.

 
![Captura de pantalla 2024-12-30 231937](https://github.com/user-attachments/assets/b91f7f4b-51b0-4b0f-b8aa-af050b4b21b3)
