### PR TITLE
feat:add banner top for unverified

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,22 +1,11 @@
 "use client";
 
-import { FilledButton } from '@/components/ui/FilledButton'
-import { Check, AlertTriangle } from 'lucide-react'
+import { BannerTop } from '@/components/ui/BannerTop'
 
 export default function Home() {
   return (
-    <div className="flex min-h-screen items-center justify-center gap-4">
-      <FilledButton>
-        Click me!
-      </FilledButton>
-
-      <FilledButton variant="success" size="md" icon={Check}>
-        Success
-      </FilledButton>
-
-      <FilledButton variant="warning" size="lg" icon={AlertTriangle}>
-        Warning
-      </FilledButton>
+    <div className="flex min-h-screen flex-col">
+      <BannerTop />
     </div>
   )
 }

--- a/frontend/src/components/ui/BannerTop.tsx
+++ b/frontend/src/components/ui/BannerTop.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils"
+
+interface BannerTopProps {
+  message?: string;
+  variant?: 'warning' | 'success';
+  className?: string;
+}
+
+export function BannerTop({ 
+  message = "Unverified",
+  variant = 'warning',
+  className
+}: BannerTopProps) {
+  return (
+    <div className={cn(
+      "relative w-full h-[43px] overflow-hidden",
+      className
+    )}>
+      <div className={cn(
+        "absolute inset-x-0 top-0 h-full",
+        variant === 'warning' ? 'bg-accent-red' : 'bg-brand-primary'
+      )} />
+      <div className="absolute inset-0 flex items-center justify-center">
+        <span className="text-white text-xl font-bold font-spaceGrotesk">
+          {message}
+        </span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
closes #14

<img width="352" alt="Screenshot 2024-12-31 at 1 34 32 PM" src="https://github.com/user-attachments/assets/8849d8d4-1f19-43f5-95ee-b23cd5ae9208" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `BannerTop` component with configurable message and variant options
	- Updated home page layout to display a banner

- **Refactor**
	- Removed previous button components from the home page
	- Simplified page structure with vertical banner layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->