### PR TITLE
feat: add insights endpoints

### DIFF
--- a/frontend/src/app/api/insights/[testId]/route.ts
+++ b/frontend/src/app/api/insights/[testId]/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { getXataClient } from "@/lib/utils";
+
+/**
+ * @swagger
+ * /api/insights/{testId}:
+ *   get:
+ *     summary: Get insights for a specific test
+ *     description: Retrieves all insights for a test, organized by category
+ *     parameters:
+ *       - name: testId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved test insights
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 insights:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       category:
+ *                         type: string
+ *                       left_percentage:
+ *                         type: number
+ *                       right_percentage:
+ *                         type: number
+ *                       description:
+ *                         type: string
+ *                       insight:
+ *                         type: string
+ *       400:
+ *         description: Invalid test ID
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Test, user, or insights not found
+ *       500:
+ *         description: Internal server error
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: { testId: string } }
+) {
+  try {
+    // TODO: Remove this once we have a proper auth system
+    const session = await getServerSession();
+    const userEmail = session?.user?.email;
+
+    if (!userEmail) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const xata = getXataClient();
+    
+    // Validate test ID
+    const testId = parseInt(params.testId);
+    if (Number.isNaN(testId) || testId <= 0) {
+      return NextResponse.json(
+        { error: "Invalid test ID" },
+        { status: 400 }
+      );
+    }
+
+    // Get user
+    const user = await xata.db.Users.filter({ email: userEmail }).getFirst();
+    if (!user) {
+      return NextResponse.json(
+        { error: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    // Get test
+    const test = await xata.db.Tests.filter({ test_id: testId }).getFirst();
+    if (!test) {
+      return NextResponse.json(
+        { error: "Test not found" },
+        { status: 404 }
+      );
+    }
+
+    // Get insights for this test
+    const userInsights = await xata.db.InsightsPerUserCategory
+      .filter({
+        "user.xata_id": user.xata_id,
+        "test.test_id": testId
+      })
+      .select([
+        "category.category_name",
+        "insight.insight"
+      ])
+      .getMany();
+
+    if (!userInsights.length) {
+      return NextResponse.json(
+        { error: "No insights found for this test" },
+        { status: 404 }
+      );
+    }
+
+    // Transform and organize insights
+    const insights = userInsights.map(record => ({
+      category: record.category?.category_name,
+      // TODO: Calculate these values once schema is updated
+      left_percentage: 0,
+      right_percentage: 0,
+      // TODO: Add logic to determine description based on percentages
+      description: "Pending description",
+      insight: record.insight?.insight
+    })).filter(insight => insight.category && insight.insight); // Filter out any incomplete records
+
+    return NextResponse.json({
+      insights
+    });
+
+  } catch (error) {
+    console.error("Error fetching test insights:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch test insights" },
+      { status: 500 }
+    );
+  }
+} 

--- a/frontend/src/app/api/insights/[testId]/route.ts
+++ b/frontend/src/app/api/insights/[testId]/route.ts
@@ -128,7 +128,7 @@ export async function GET(
   } catch (error) {
     console.error("Error fetching test insights:", error);
     return NextResponse.json(
-      { error: "Failed to fetch test insights" },
+      { error: "Internal server error" },
       { status: 500 }
     );
   }

--- a/frontend/src/app/api/insights/route.ts
+++ b/frontend/src/app/api/insights/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { getXataClient } from "@/lib/utils";
+
+/**
+ * @swagger
+ * /api/insights:
+ *   get:
+ *     summary: Get tests with insights
+ *     description: Retrieves a list of tests that have insights for the user
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved tests with insights
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 tests:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       test_id:
+ *                         type: number
+ *                       test_name:
+ *                         type: string
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: User not found
+ *       500:
+ *         description: Internal server error
+ */
+export async function GET(request: Request) {
+  try {
+    // TODO: Remove this once we have a proper auth system
+    const session = await getServerSession();
+    const userEmail = session?.user?.email;
+
+    if (!userEmail) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const xata = getXataClient();
+
+    // Get user
+    const user = await xata.db.Users.filter({ email: userEmail }).getFirst();
+    if (!user) {
+      return NextResponse.json(
+        { error: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    // Get distinct tests from InsightsPerUserCategory
+    const testsWithInsights = await xata.db.InsightsPerUserCategory
+      .filter({
+        "user.xata_id": user.xata_id
+      })
+      .select([
+        "test.test_id",
+        "test.test_name"
+      ])
+      .getMany();
+
+    // Create a map to store unique tests
+    const uniqueTests = new Map();
+    
+    testsWithInsights.forEach(insight => {
+      if (insight.test?.test_id) {
+        uniqueTests.set(insight.test.test_id, {
+          test_id: insight.test.test_id,
+          test_name: insight.test.test_name
+        });
+      }
+    });
+
+    return NextResponse.json({
+      tests: Array.from(uniqueTests.values())
+    });
+
+  } catch (error) {
+    console.error("Error fetching insights:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch insights" },
+      { status: 500 }
+    );
+  }
+} 

--- a/frontend/src/app/api/tests/[testId]/finish-test/route.ts
+++ b/frontend/src/app/api/tests/[testId]/finish-test/route.ts
@@ -97,7 +97,7 @@ export async function PUT(
   } catch (error) {
     console.error("Error completing test:", error);
     return NextResponse.json(
-      { error: "Failed to complete test" },
+      { error: "Internal server error" },
       { status: 500 }
     );
   }

--- a/frontend/src/app/api/tests/[testId]/questions/[questionId]/route.ts
+++ b/frontend/src/app/api/tests/[testId]/questions/[questionId]/route.ts
@@ -287,7 +287,7 @@ export async function POST(
   } catch (error) {
     console.error("Error recording answer:", error);
     return NextResponse.json(
-      { error: "Failed to record answer" },
+      { error: "Internal server error" },
       { status: 500 }
     );
   }

--- a/frontend/src/app/api/tests/[testId]/questions/[questionId]/route.ts
+++ b/frontend/src/app/api/tests/[testId]/questions/[questionId]/route.ts
@@ -125,10 +125,12 @@ export async function GET(
       );
     }
 
+    const mapAnswers = (options: any[]) => options.map((option) => option.answer);
+    
     if (question.std_answer) {
         const options = await xata.db.StandardAnswers.getMany();
         // Make options an array of strings which are the answers
-        const answers = options.map((option) => option.answer);
+        const answers = mapAnswers(options);
 
         return NextResponse.json({
             question_text: question.question,
@@ -141,7 +143,7 @@ export async function GET(
             "question.question_id": questionId
         }).getMany();
         // Make options an array of strings which are the answers
-        const answers = options.map((option) => option.answer);
+        const answers = mapAnswers(options);
         return NextResponse.json({
             question_text: question.question,
             answers: answers


### PR DESCRIPTION
Closes #73 and #74

Add the following endpoints:
- Method: GET `/api/insights`
- Method: GET `/api/insights/{testId}`

It fetches the tests made by the user in the InsightsPerUserCategory to display them in the Insights Selection Page. All the insights from said test are fetched by the testId for the Insights Page

Some TODOs left are the following:
- Do testing of the API endpoint
- Implement auth properly to retrieve user (would be fixed by #63)
- Modify the schema to include percentages (left and right percentage)
- Modify the schema to include a small description (centrist, leftist, rightist, etc)

The last 2 TODOs will be implemented once the test logic is done, the table that should the percentages and description column are the `InsightsPerUserCategory` 
    
    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added API endpoints for retrieving insights for specific tests.
	- Implemented functionality to mark a test as completed.
	- Created routes for fetching and answering test questions.
	- Added input validation for test and question IDs.

- **Bug Fixes**
	- Improved error handling for various API scenarios.
	- Enhanced authentication checks for API routes.

- **Security Improvements**
	- Added user session validation.
	- Implemented authorization checks for API endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->