### PR TITLE
feat: add results endpoint

### DIFF
--- a/frontend/.xata/migrations/.ledger
+++ b/frontend/.xata/migrations/.ledger
@@ -91,3 +91,14 @@ mig_cu8uh27lmd4pfs40o370
 mig_cu8ui17lmd4pfs40o380
 mig_cu8ui7flmd4pfs40o390
 mig_cu8uib634skj7mihmmr0
+mig_cua6fkm34skj7mihn0sg
+mig_cua6g1nlmd4pfs40ocpg
+mig_cua76eutrfea4ndanmjg
+mig_cua7717lmd4pfs40ocv0
+mig_cubbllflmd4pfs40ol2g
+mig_cubbm0utrfea4ndanu2g
+mig_cubbmbetrfea4ndanu3g
+mig_cubbnj634skj7mihnap0
+mig_cubbp4m34skj7mihnaq0
+mig_cubbpcnlmd4pfs40ol60
+mig_cublhputrfea4ndanvq0

--- a/frontend/.xata/migrations/mig_cua6fkm34skj7mihn0sg.json
+++ b/frontend/.xata/migrations/mig_cua6fkm34skj7mihn0sg.json
@@ -1,0 +1,24 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cua6fkm34skj7mihn0sg",
+    "operations": [
+      {
+        "add_column": {
+          "table": "Questions",
+          "column": {
+            "name": "effect",
+            "type": "json",
+            "comment": "",
+            "nullable": true
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cua6fkm34skj7mihn0sg",
+  "parent": "mig_cu8uib634skj7mihmmr0",
+  "schema": "public",
+  "startedAt": "2025-01-25T04:25:55.636712Z"
+}

--- a/frontend/.xata/migrations/mig_cua6g1nlmd4pfs40ocpg.json
+++ b/frontend/.xata/migrations/mig_cua6g1nlmd4pfs40ocpg.json
@@ -1,0 +1,22 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cua6g1nlmd4pfs40ocpg",
+    "operations": [
+      {
+        "alter_column": {
+          "up": "(SELECT CASE WHEN \"effect\" IS NULL THEN '{}' ELSE \"effect\" END)",
+          "down": "(SELECT CASE WHEN \"effect\" IS NULL THEN '{}' ELSE \"effect\" END)",
+          "table": "Questions",
+          "column": "effect",
+          "nullable": false
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cua6g1nlmd4pfs40ocpg",
+  "parent": "mig_cua6fkm34skj7mihn0sg",
+  "schema": "public",
+  "startedAt": "2025-01-25T04:26:47.952487Z"
+}

--- a/frontend/.xata/migrations/mig_cua76eutrfea4ndanmjg.json
+++ b/frontend/.xata/migrations/mig_cua76eutrfea4ndanmjg.json
@@ -1,0 +1,20 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cua76eutrfea4ndanmjg",
+    "operations": [
+      {
+        "drop_column": {
+          "down": "0",
+          "table": "UserTestProgress",
+          "column": "user_progress_id"
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cua76eutrfea4ndanmjg",
+  "parent": "mig_cua6g1nlmd4pfs40ocpg",
+  "schema": "public",
+  "startedAt": "2025-01-25T05:14:35.84235Z"
+}

--- a/frontend/.xata/migrations/mig_cua7717lmd4pfs40ocv0.json
+++ b/frontend/.xata/migrations/mig_cua7717lmd4pfs40ocv0.json
@@ -1,0 +1,20 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cua7717lmd4pfs40ocv0",
+    "operations": [
+      {
+        "alter_column": {
+          "name": "current_question",
+          "table": "UserTestProgress",
+          "column": "question"
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cua7717lmd4pfs40ocv0",
+  "parent": "mig_cua76eutrfea4ndanmjg",
+  "schema": "public",
+  "startedAt": "2025-01-25T05:15:49.270034Z"
+}

--- a/frontend/.xata/migrations/mig_cubbllflmd4pfs40ol2g.json
+++ b/frontend/.xata/migrations/mig_cubbllflmd4pfs40ol2g.json
@@ -1,0 +1,20 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cubbllflmd4pfs40ol2g",
+    "operations": [
+      {
+        "drop_column": {
+          "down": "0",
+          "table": "InsightsPerUserCategory",
+          "column": "right_percentage"
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cubbllflmd4pfs40ol2g",
+  "parent": "mig_cua7717lmd4pfs40ocv0",
+  "schema": "public",
+  "startedAt": "2025-01-26T22:44:39.080397Z"
+}

--- a/frontend/.xata/migrations/mig_cubbm0utrfea4ndanu2g.json
+++ b/frontend/.xata/migrations/mig_cubbm0utrfea4ndanu2g.json
@@ -1,0 +1,20 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cubbm0utrfea4ndanu2g",
+    "operations": [
+      {
+        "alter_column": {
+          "name": "percentage",
+          "table": "InsightsPerUserCategory",
+          "column": "left_percentage"
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cubbm0utrfea4ndanu2g",
+  "parent": "mig_cubbllflmd4pfs40ol2g",
+  "schema": "public",
+  "startedAt": "2025-01-26T22:45:24.302166Z"
+}

--- a/frontend/.xata/migrations/mig_cubbmbetrfea4ndanu3g.json
+++ b/frontend/.xata/migrations/mig_cubbmbetrfea4ndanu3g.json
@@ -1,0 +1,57 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cubbmbetrfea4ndanu3g",
+    "operations": [
+      {
+        "create_table": {
+          "name": "Payments",
+          "columns": [
+            {
+              "name": "xata_id",
+              "type": "text",
+              "check": {
+                "name": "Payments_xata_id_length_xata_id",
+                "constraint": "length(\"xata_id\") < 256"
+              },
+              "unique": true,
+              "default": "'rec_' || xata_private.xid()"
+            },
+            {
+              "name": "xata_version",
+              "type": "integer",
+              "default": "0"
+            },
+            {
+              "name": "xata_createdat",
+              "type": "timestamptz",
+              "default": "now()"
+            },
+            {
+              "name": "xata_updatedat",
+              "type": "timestamptz",
+              "default": "now()"
+            }
+          ]
+        }
+      },
+      {
+        "sql": {
+          "up": "ALTER TABLE \"Payments\" REPLICA IDENTITY FULL",
+          "onComplete": true
+        }
+      },
+      {
+        "sql": {
+          "up": "CREATE TRIGGER xata_maintain_metadata_trigger_pgroll\n  BEFORE INSERT OR UPDATE\n  ON \"Payments\"\n  FOR EACH ROW\n  EXECUTE FUNCTION xata_private.maintain_metadata_trigger_pgroll()",
+          "onComplete": true
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cubbmbetrfea4ndanu3g",
+  "parent": "mig_cubbm0utrfea4ndanu2g",
+  "schema": "public",
+  "startedAt": "2025-01-26T22:46:05.455313Z"
+}

--- a/frontend/.xata/migrations/mig_cubbnj634skj7mihnap0.json
+++ b/frontend/.xata/migrations/mig_cubbnj634skj7mihnap0.json
@@ -1,0 +1,25 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cubbnj634skj7mihnap0",
+    "operations": [
+      {
+        "add_column": {
+          "up": "0",
+          "table": "Payments",
+          "column": {
+            "name": "payment_id",
+            "type": "int",
+            "unique": true,
+            "comment": ""
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cubbnj634skj7mihnap0",
+  "parent": "mig_cubbmbetrfea4ndanu3g",
+  "schema": "public",
+  "startedAt": "2025-01-26T22:48:45.473131Z"
+}

--- a/frontend/.xata/migrations/mig_cubbp4m34skj7mihnaq0.json
+++ b/frontend/.xata/migrations/mig_cubbp4m34skj7mihnaq0.json
@@ -1,0 +1,24 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cubbp4m34skj7mihnaq0",
+    "operations": [
+      {
+        "add_column": {
+          "up": "''",
+          "table": "Payments",
+          "column": {
+            "name": "uuid",
+            "type": "text",
+            "comment": ""
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cubbp4m34skj7mihnaq0",
+  "parent": "mig_cubbnj634skj7mihnap0",
+  "schema": "public",
+  "startedAt": "2025-01-26T22:52:03.520728Z"
+}

--- a/frontend/.xata/migrations/mig_cubbpcnlmd4pfs40ol60.json
+++ b/frontend/.xata/migrations/mig_cubbpcnlmd4pfs40ol60.json
@@ -1,0 +1,30 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cubbpcnlmd4pfs40ol60",
+    "operations": [
+      {
+        "add_column": {
+          "up": "''",
+          "table": "Payments",
+          "column": {
+            "name": "user",
+            "type": "text",
+            "comment": "{\"xata.link\":\"Users\"}",
+            "references": {
+              "name": "user_link",
+              "table": "Users",
+              "column": "xata_id",
+              "on_delete": "SET NULL"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cubbpcnlmd4pfs40ol60",
+  "parent": "mig_cubbp4m34skj7mihnaq0",
+  "schema": "public",
+  "startedAt": "2025-01-26T22:52:35.614585Z"
+}

--- a/frontend/.xata/migrations/mig_cublhputrfea4ndanvq0.json
+++ b/frontend/.xata/migrations/mig_cublhputrfea4ndanvq0.json
@@ -1,0 +1,24 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cublhputrfea4ndanvq0",
+    "operations": [
+      {
+        "add_column": {
+          "up": "'{}'",
+          "table": "UserTestProgress",
+          "column": {
+            "name": "score",
+            "type": "json",
+            "comment": ""
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cublhputrfea4ndanvq0",
+  "parent": "mig_cubbpcnlmd4pfs40ol60",
+  "schema": "public",
+  "startedAt": "2025-01-27T09:59:03.907268Z"
+}

--- a/frontend/src/app/api/tests/[testId]/results/route.ts
+++ b/frontend/src/app/api/tests/[testId]/results/route.ts
@@ -1,0 +1,175 @@
+import { getXataClient } from "@/lib/utils";
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+
+interface CategoryScore {
+  category_xata_id: string;
+  score: number;
+}
+
+/**
+ * @swagger
+ * /api/tests/{testId}/results:
+ *   get:
+ *     summary: Get test results and insights
+ *     description: Retrieves test scores and generates insights based on user's answers
+ *     parameters:
+ *       - name: testId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Successfully retrieved test results and insights
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 type: object
+ *                 properties:
+ *                   category:
+ *                     type: string
+ *                     example: "Economic"
+ *                   insight:
+ *                     type: string
+ *                     example: "You relate more to..."
+ *                   description:
+ *                     type: string
+ *                     example: "Centrist"
+ *                   percentage:
+ *                     type: number
+ *                     example: 40
+ *       401:
+ *         description: Unauthorized
+ *       404:
+ *         description: Test progress not found
+ *       500:
+ *         description: Internal server error
+ */
+export async function GET(
+  request: Request,
+  { params }: { params: { testId: string } }
+) {
+  try {
+    // TODO: Remove this once we have a proper auth system
+    const session = await getServerSession();
+    const userEmail = session?.user?.email;
+
+    if (!userEmail) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const xata = getXataClient();
+    
+    // Get user
+    const user = await xata.db.Users.filter({ email: userEmail }).getFirst();
+    if (!user) {
+      return NextResponse.json(
+        { error: "User not found" },
+        { status: 404 }
+      );
+    }
+
+    // Get test progress
+    const progress = await xata.db.UserTestProgress.filter({
+      "user.xata_id": user.xata_id,
+      "test.test_id": parseInt(params.testId)
+    }).getFirst();
+
+    if (!progress) {
+      return NextResponse.json(
+        { error: "Test progress not found" },
+        { status: 404 }
+      );
+    }
+
+    if (!progress.score) {
+      return NextResponse.json(
+        { error: "Test not completed" },
+        { status: 400 }
+      );
+    }
+
+    // Get all categories with their names
+    const categories = await xata.db.Categories.getAll();
+    
+    // Map scores to categories
+    const categoryScores: CategoryScore[] = [
+      { category_xata_id: categories.find(c => c.category_name === "Economic")?.xata_id || "", score: progress.score.economic },
+      { category_xata_id: categories.find(c => c.category_name === "Civil")?.xata_id || "", score: progress.score.civil },
+      { category_xata_id: categories.find(c => c.category_name === "Diplomatic")?.xata_id || "", score: progress.score.diplomatic },
+      { category_xata_id: categories.find(c => c.category_name === "Societal")?.xata_id || "", score: progress.score.societal }
+    ].filter(cs => cs.category_xata_id !== "");
+
+    // Process each category score
+    const results = [];
+    const test = await xata.db.Tests.filter({ test_id: parseInt(params.testId) }).getFirst();
+
+    if (!test) {
+      return NextResponse.json(
+        { error: "Test not found" },
+        { status: 404 }
+      );
+    }
+
+    for (const categoryScore of categoryScores) {
+      // Find matching insight based on score
+      const insight = await xata.db.Insights.filter({
+        "category.xata_id": categoryScore.category_xata_id,
+        lower_limit: { $le: categoryScore.score },
+        upper_limit: { $gt: categoryScore.score }
+      }).getFirst();
+
+      if (insight) {
+        // Get category details
+        const category = categories.find(c => c.xata_id === categoryScore.category_xata_id);
+        
+        if (category) {
+          // Save to InsightsPerUserCategory
+          const latestInsight = await xata.db.InsightsPerUserCategory
+            .sort("insight_user_id", "desc")
+            .getFirst();
+          const nextInsightId = (latestInsight?.insight_user_id || 0) + 1;
+
+          await xata.db.InsightsPerUserCategory.create({
+            category: category.xata_id,
+            insight: insight.xata_id,
+            test: test.xata_id,
+            user: user.xata_id,
+            description: insight.insight,
+            percentage: categoryScore.score,
+            insight_user_id: nextInsightId
+          });
+
+          // Add to results
+          results.push({
+            category: category.category_name,
+            insight: insight.insight,
+            description: insight.insight,
+            percentage: categoryScore.score
+          });
+        }
+      }
+    }
+
+    // Update progress status to completed
+    await progress.update({
+      status: "completed",
+      completed_at: new Date()
+    });
+
+    return NextResponse.json(results);
+
+  } catch (error) {
+    console.error("Error processing test results:", error);
+    return NextResponse.json(
+      { error: "Failed to process test results" },
+      { status: 500 }
+    );
+  }
+}

--- a/frontend/src/lib/xata.ts
+++ b/frontend/src/lib/xata.ts
@@ -485,15 +485,7 @@ const tables = [
         comment: "",
       },
       {
-        name: "left_percentage",
-        type: "int",
-        notNull: true,
-        unique: false,
-        defaultValue: null,
-        comment: "",
-      },
-      {
-        name: "right_percentage",
+        name: "percentage",
         type: "int",
         notNull: true,
         unique: false,
@@ -517,6 +509,95 @@ const tables = [
         unique: false,
         defaultValue: null,
         comment: '{"xata.link":"Users"}',
+      },
+      {
+        name: "xata_createdat",
+        type: "datetime",
+        notNull: true,
+        unique: false,
+        defaultValue: "now()",
+        comment: "",
+      },
+      {
+        name: "xata_id",
+        type: "text",
+        notNull: true,
+        unique: true,
+        defaultValue: "('rec_'::text || (xata_private.xid())::text)",
+        comment: "",
+      },
+      {
+        name: "xata_updatedat",
+        type: "datetime",
+        notNull: true,
+        unique: false,
+        defaultValue: "now()",
+        comment: "",
+      },
+      {
+        name: "xata_version",
+        type: "int",
+        notNull: true,
+        unique: false,
+        defaultValue: "0",
+        comment: "",
+      },
+    ],
+  },
+  {
+    name: "Payments",
+    checkConstraints: {
+      Payments_xata_id_length_xata_id: {
+        name: "Payments_xata_id_length_xata_id",
+        columns: ["xata_id"],
+        definition: "CHECK ((length(xata_id) < 256))",
+      },
+    },
+    foreignKeys: {
+      user_link: {
+        name: "user_link",
+        columns: ["user"],
+        referencedTable: "Users",
+        referencedColumns: ["xata_id"],
+        onDelete: "SET NULL",
+      },
+    },
+    primaryKey: [],
+    uniqueConstraints: {
+      Payments__pgroll_new_payment_id_key: {
+        name: "Payments__pgroll_new_payment_id_key",
+        columns: ["payment_id"],
+      },
+      _pgroll_new_Payments_xata_id_key: {
+        name: "_pgroll_new_Payments_xata_id_key",
+        columns: ["xata_id"],
+      },
+    },
+    columns: [
+      {
+        name: "payment_id",
+        type: "int",
+        notNull: true,
+        unique: true,
+        defaultValue: null,
+        comment: "",
+      },
+      {
+        name: "user",
+        type: "link",
+        link: { table: "Users" },
+        notNull: true,
+        unique: false,
+        defaultValue: null,
+        comment: '{"xata.link":"Users"}',
+      },
+      {
+        name: "uuid",
+        type: "text",
+        notNull: true,
+        unique: false,
+        defaultValue: null,
+        comment: "",
       },
       {
         name: "xata_createdat",
@@ -686,6 +767,14 @@ const tables = [
         unique: false,
         defaultValue: null,
         comment: '{"xata.link":"Areas"}',
+      },
+      {
+        name: "effect",
+        type: "json",
+        notNull: true,
+        unique: false,
+        defaultValue: null,
+        comment: "",
       },
       {
         name: "question",
@@ -1022,7 +1111,7 @@ const tables = [
     foreignKeys: {
       question_link: {
         name: "question_link",
-        columns: ["question"],
+        columns: ["current_question"],
         referencedTable: "Questions",
         referencedColumns: ["xata_id"],
         onDelete: "SET NULL",
@@ -1044,10 +1133,6 @@ const tables = [
     },
     primaryKey: [],
     uniqueConstraints: {
-      UserTestProgress__pgroll_new_user_progress_id_key: {
-        name: "UserTestProgress__pgroll_new_user_progress_id_key",
-        columns: ["user_progress_id"],
-      },
       _pgroll_new_UserTestProgress_xata_id_key: {
         name: "_pgroll_new_UserTestProgress_xata_id_key",
         columns: ["xata_id"],
@@ -1071,13 +1156,21 @@ const tables = [
         comment: "",
       },
       {
-        name: "question",
+        name: "current_question",
         type: "link",
         link: { table: "Questions" },
         notNull: true,
         unique: false,
         defaultValue: null,
         comment: '{"xata.link":"Questions"}',
+      },
+      {
+        name: "score",
+        type: "json",
+        notNull: true,
+        unique: false,
+        defaultValue: null,
+        comment: "",
       },
       {
         name: "started_at",
@@ -1112,14 +1205,6 @@ const tables = [
         unique: false,
         defaultValue: null,
         comment: '{"xata.link":"Users"}',
-      },
-      {
-        name: "user_progress_id",
-        type: "int",
-        notNull: true,
-        unique: true,
-        defaultValue: null,
-        comment: "",
       },
       {
         name: "xata_createdat",
@@ -1487,6 +1572,9 @@ export type InsightsPerUserCategory = InferredTypes["InsightsPerUserCategory"];
 export type InsightsPerUserCategoryRecord = InsightsPerUserCategory &
   XataRecord;
 
+export type Payments = InferredTypes["Payments"];
+export type PaymentsRecord = Payments & XataRecord;
+
 export type PersonalizedAnswers = InferredTypes["PersonalizedAnswers"];
 export type PersonalizedAnswersRecord = PersonalizedAnswers & XataRecord;
 
@@ -1517,6 +1605,7 @@ export type DatabaseSchema = {
   Countries: CountriesRecord;
   Insights: InsightsRecord;
   InsightsPerUserCategory: InsightsPerUserCategoryRecord;
+  Payments: PaymentsRecord;
   PersonalizedAnswers: PersonalizedAnswersRecord;
   Questions: QuestionsRecord;
   Regions: RegionsRecord;


### PR DESCRIPTION
Closes #21 

This PR adds the following flow:
1. Fetch the scores from the user progress
2. Link each score to their category, this means grabbing the xata_id from Category. It should turn out in something like the following JSON: [ {category_xata_id: rec_xxx, score: xx}, {category_xata_id: rec_xxx, score: xx}, ... ]
3. Seek the insight according to the score (checking the score lies between the upper and lower in the Insights table), and save it. This means grabbing the xata_id from the Insight.
4. Save the insights in UserInsightsPerCategory table with all the data.

The endpoint should return the following JSON for the frontend to display information properly:

[
{ category: Economic, 
insight: You relate more....,
description: Centrist,
percentage: 40
},
{ category: Civil, 
insight: You help....,
description: Leftist, 
percentage: 20
},
...
]

Flow used for the endpoint in an image:
![image](https://github.com/user-attachments/assets/cdb6edd2-68d3-421a-928b-6028cb93b43d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Database Migrations**
	- Added multiple database migrations for various tables
	- Introduced new `Payments` table
	- Updated `Questions`, `UserTestProgress`, and `InsightsPerUserCategory` tables

- **API Enhancements**
	- Added new endpoint for retrieving test results
	- Improved handling of user test progress and scores

- **Schema Updates**
	- Added new columns like `effect`, `score`, and `payment_id`
	- Introduced foreign key relationships and metadata columns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->