### PR TITLE
add: xata db migrations

### DIFF
--- a/frontend/.xata/migrations/.ledger
+++ b/frontend/.xata/migrations/.ledger
@@ -116,3 +116,13 @@ mig_cuh0t5hi7viit4iimsjg
 mig_cuh0t9jiojibbahcj0n0
 mig_cuh0thjiojibbahcj0p0
 mig_cuh0tmriojibbahcj0q0
+mig_cuh562rrr2giaepaghv0
+mig_cuh7dfbrr2giaepagif0
+mig_cuh7eghi7viit4iimuv0
+mig_cuh7f4brr2giaepagij0
+mig_cuh7fd9i7viit4iimv00
+mig_cuh7l4hi7viit4iimvag
+mig_cuh7mbjrr2giaepagis0
+mig_cuh7mp1i7viit4iimvcg
+mig_cuh7n71i7viit4iimvdg
+mig_cuh7vupi7viit4iimvgg

--- a/frontend/.xata/migrations/mig_cuh562rrr2giaepaghv0.json
+++ b/frontend/.xata/migrations/mig_cuh562rrr2giaepaghv0.json
@@ -1,0 +1,21 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cuh562rrr2giaepaghv0",
+    "operations": [
+      {
+        "drop_constraint": {
+          "up": "\"user\"",
+          "down": "\"user\"",
+          "name": "IdeologyPerUser__pgroll_new_user_key",
+          "table": "IdeologyPerUser"
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cuh562rrr2giaepaghv0",
+  "parent": "mig_cuh0tmriojibbahcj0q0",
+  "schema": "public",
+  "startedAt": "2025-02-04T17:48:59.96206Z"
+}

--- a/frontend/.xata/migrations/mig_cuh7dfbrr2giaepagif0.json
+++ b/frontend/.xata/migrations/mig_cuh7dfbrr2giaepagif0.json
@@ -1,0 +1,57 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cuh7dfbrr2giaepagif0",
+    "operations": [
+      {
+        "create_table": {
+          "name": "PublicFigures",
+          "columns": [
+            {
+              "name": "xata_id",
+              "type": "text",
+              "check": {
+                "name": "PublicFigures_xata_id_length_xata_id",
+                "constraint": "length(\"xata_id\") < 256"
+              },
+              "unique": true,
+              "default": "'rec_' || xata_private.xid()"
+            },
+            {
+              "name": "xata_version",
+              "type": "integer",
+              "default": "0"
+            },
+            {
+              "name": "xata_createdat",
+              "type": "timestamptz",
+              "default": "now()"
+            },
+            {
+              "name": "xata_updatedat",
+              "type": "timestamptz",
+              "default": "now()"
+            }
+          ]
+        }
+      },
+      {
+        "sql": {
+          "up": "ALTER TABLE \"PublicFigures\" REPLICA IDENTITY FULL",
+          "onComplete": true
+        }
+      },
+      {
+        "sql": {
+          "up": "CREATE TRIGGER xata_maintain_metadata_trigger_pgroll\n  BEFORE INSERT OR UPDATE\n  ON \"PublicFigures\"\n  FOR EACH ROW\n  EXECUTE FUNCTION xata_private.maintain_metadata_trigger_pgroll()",
+          "onComplete": true
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cuh7dfbrr2giaepagif0",
+  "parent": "mig_cuh562rrr2giaepaghv0",
+  "schema": "public",
+  "startedAt": "2025-02-04T20:21:18.247626Z"
+}

--- a/frontend/.xata/migrations/mig_cuh7eghi7viit4iimuv0.json
+++ b/frontend/.xata/migrations/mig_cuh7eghi7viit4iimuv0.json
@@ -1,0 +1,24 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cuh7eghi7viit4iimuv0",
+    "operations": [
+      {
+        "add_column": {
+          "up": "0",
+          "table": "PublicFigures",
+          "column": {
+            "name": "celebrity_id",
+            "type": "int",
+            "comment": ""
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cuh7eghi7viit4iimuv0",
+  "parent": "mig_cuh7dfbrr2giaepagif0",
+  "schema": "public",
+  "startedAt": "2025-02-04T20:23:31.253659Z"
+}

--- a/frontend/.xata/migrations/mig_cuh7f4brr2giaepagij0.json
+++ b/frontend/.xata/migrations/mig_cuh7f4brr2giaepagij0.json
@@ -1,0 +1,25 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cuh7f4brr2giaepagij0",
+    "operations": [
+      {
+        "add_column": {
+          "up": "''",
+          "table": "PublicFigures",
+          "column": {
+            "name": "name",
+            "type": "text",
+            "unique": true,
+            "comment": ""
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cuh7f4brr2giaepagij0",
+  "parent": "mig_cuh7eghi7viit4iimuv0",
+  "schema": "public",
+  "startedAt": "2025-02-04T20:24:50.837953Z"
+}

--- a/frontend/.xata/migrations/mig_cuh7fd9i7viit4iimv00.json
+++ b/frontend/.xata/migrations/mig_cuh7fd9i7viit4iimv00.json
@@ -1,0 +1,24 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cuh7fd9i7viit4iimv00",
+    "operations": [
+      {
+        "add_column": {
+          "up": "'{}'",
+          "table": "PublicFigures",
+          "column": {
+            "name": "scores",
+            "type": "json",
+            "comment": ""
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cuh7fd9i7viit4iimv00",
+  "parent": "mig_cuh7f4brr2giaepagij0",
+  "schema": "public",
+  "startedAt": "2025-02-04T20:25:26.08333Z"
+}

--- a/frontend/.xata/migrations/mig_cuh7l4hi7viit4iimvag.json
+++ b/frontend/.xata/migrations/mig_cuh7l4hi7viit4iimvag.json
@@ -1,0 +1,57 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cuh7l4hi7viit4iimvag",
+    "operations": [
+      {
+        "create_table": {
+          "name": "PublicFigurePerUser",
+          "columns": [
+            {
+              "name": "xata_id",
+              "type": "text",
+              "check": {
+                "name": "PublicFigurePerUser_xata_id_length_xata_id",
+                "constraint": "length(\"xata_id\") < 256"
+              },
+              "unique": true,
+              "default": "'rec_' || xata_private.xid()"
+            },
+            {
+              "name": "xata_version",
+              "type": "integer",
+              "default": "0"
+            },
+            {
+              "name": "xata_createdat",
+              "type": "timestamptz",
+              "default": "now()"
+            },
+            {
+              "name": "xata_updatedat",
+              "type": "timestamptz",
+              "default": "now()"
+            }
+          ]
+        }
+      },
+      {
+        "sql": {
+          "up": "ALTER TABLE \"PublicFigurePerUser\" REPLICA IDENTITY FULL",
+          "onComplete": true
+        }
+      },
+      {
+        "sql": {
+          "up": "CREATE TRIGGER xata_maintain_metadata_trigger_pgroll\n  BEFORE INSERT OR UPDATE\n  ON \"PublicFigurePerUser\"\n  FOR EACH ROW\n  EXECUTE FUNCTION xata_private.maintain_metadata_trigger_pgroll()",
+          "onComplete": true
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cuh7l4hi7viit4iimvag",
+  "parent": "mig_cuh7fd9i7viit4iimv00",
+  "schema": "public",
+  "startedAt": "2025-02-04T20:37:39.593378Z"
+}

--- a/frontend/.xata/migrations/mig_cuh7mbjrr2giaepagis0.json
+++ b/frontend/.xata/migrations/mig_cuh7mbjrr2giaepagis0.json
@@ -1,0 +1,30 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cuh7mbjrr2giaepagis0",
+    "operations": [
+      {
+        "add_column": {
+          "up": "''",
+          "table": "PublicFigurePerUser",
+          "column": {
+            "name": "public_figure",
+            "type": "text",
+            "comment": "{\"xata.link\":\"PublicFigures\"}",
+            "references": {
+              "name": "public_figure_link",
+              "table": "PublicFigures",
+              "column": "xata_id",
+              "on_delete": "SET NULL"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cuh7mbjrr2giaepagis0",
+  "parent": "mig_cuh7l4hi7viit4iimvag",
+  "schema": "public",
+  "startedAt": "2025-02-04T20:40:15.463499Z"
+}

--- a/frontend/.xata/migrations/mig_cuh7mp1i7viit4iimvcg.json
+++ b/frontend/.xata/migrations/mig_cuh7mp1i7viit4iimvcg.json
@@ -1,0 +1,24 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cuh7mp1i7viit4iimvcg",
+    "operations": [
+      {
+        "add_column": {
+          "up": "0",
+          "table": "PublicFigurePerUser",
+          "column": {
+            "name": "celebrity_user_id",
+            "type": "int",
+            "comment": ""
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cuh7mp1i7viit4iimvcg",
+  "parent": "mig_cuh7mbjrr2giaepagis0",
+  "schema": "public",
+  "startedAt": "2025-02-04T20:41:08.986826Z"
+}

--- a/frontend/.xata/migrations/mig_cuh7n71i7viit4iimvdg.json
+++ b/frontend/.xata/migrations/mig_cuh7n71i7viit4iimvdg.json
@@ -1,0 +1,30 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cuh7n71i7viit4iimvdg",
+    "operations": [
+      {
+        "add_column": {
+          "up": "''",
+          "table": "PublicFigurePerUser",
+          "column": {
+            "name": "user",
+            "type": "text",
+            "comment": "{\"xata.link\":\"Users\"}",
+            "references": {
+              "name": "user_link",
+              "table": "Users",
+              "column": "xata_id",
+              "on_delete": "SET NULL"
+            }
+          }
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cuh7n71i7viit4iimvdg",
+  "parent": "mig_cuh7mp1i7viit4iimvcg",
+  "schema": "public",
+  "startedAt": "2025-02-04T20:42:05.313623Z"
+}

--- a/frontend/.xata/migrations/mig_cuh7vupi7viit4iimvgg.json
+++ b/frontend/.xata/migrations/mig_cuh7vupi7viit4iimvgg.json
@@ -1,0 +1,20 @@
+{
+  "done": true,
+  "migration": {
+    "name": "mig_cuh7vupi7viit4iimvgg",
+    "operations": [
+      {
+        "alter_column": {
+          "name": "celebrity",
+          "table": "PublicFigurePerUser",
+          "column": "public_figure"
+        }
+      }
+    ]
+  },
+  "migrationType": "pgroll",
+  "name": "mig_cuh7vupi7viit4iimvgg",
+  "parent": "mig_cuh7n71i7viit4iimvdg",
+  "schema": "public",
+  "startedAt": "2025-02-04T21:00:43.682753Z"
+}

--- a/frontend/src/lib/xata.ts
+++ b/frontend/src/lib/xata.ts
@@ -417,10 +417,6 @@ const tables = [
     },
     primaryKey: [],
     uniqueConstraints: {
-      IdeologyPerUser__pgroll_new_user_key: {
-        name: "IdeologyPerUser__pgroll_new_user_key",
-        columns: ["user"],
-      },
       _pgroll_new_IdeologyPerUser_xata_id_key: {
         name: "_pgroll_new_IdeologyPerUser_xata_id_key",
         columns: ["xata_id"],
@@ -449,7 +445,7 @@ const tables = [
         type: "link",
         link: { table: "Users" },
         notNull: true,
-        unique: true,
+        unique: false,
         defaultValue: null,
         comment: '{"xata.link":"Users"}',
       },
@@ -880,6 +876,179 @@ const tables = [
         unique: false,
         defaultValue: null,
         comment: '{"xata.link":"Questions"}',
+      },
+      {
+        name: "xata_createdat",
+        type: "datetime",
+        notNull: true,
+        unique: false,
+        defaultValue: "now()",
+        comment: "",
+      },
+      {
+        name: "xata_id",
+        type: "text",
+        notNull: true,
+        unique: true,
+        defaultValue: "('rec_'::text || (xata_private.xid())::text)",
+        comment: "",
+      },
+      {
+        name: "xata_updatedat",
+        type: "datetime",
+        notNull: true,
+        unique: false,
+        defaultValue: "now()",
+        comment: "",
+      },
+      {
+        name: "xata_version",
+        type: "int",
+        notNull: true,
+        unique: false,
+        defaultValue: "0",
+        comment: "",
+      },
+    ],
+  },
+  {
+    name: "PublicFigurePerUser",
+    checkConstraints: {
+      PublicFigurePerUser_xata_id_length_xata_id: {
+        name: "PublicFigurePerUser_xata_id_length_xata_id",
+        columns: ["xata_id"],
+        definition: "CHECK ((length(xata_id) < 256))",
+      },
+    },
+    foreignKeys: {
+      public_figure_link: {
+        name: "public_figure_link",
+        columns: ["celebrity"],
+        referencedTable: "PublicFigures",
+        referencedColumns: ["xata_id"],
+        onDelete: "SET NULL",
+      },
+      user_link: {
+        name: "user_link",
+        columns: ["user"],
+        referencedTable: "Users",
+        referencedColumns: ["xata_id"],
+        onDelete: "SET NULL",
+      },
+    },
+    primaryKey: [],
+    uniqueConstraints: {
+      _pgroll_new_PublicFigurePerUser_xata_id_key: {
+        name: "_pgroll_new_PublicFigurePerUser_xata_id_key",
+        columns: ["xata_id"],
+      },
+    },
+    columns: [
+      {
+        name: "celebrity",
+        type: "link",
+        link: { table: "PublicFigures" },
+        notNull: true,
+        unique: false,
+        defaultValue: null,
+        comment: '{"xata.link":"PublicFigures"}',
+      },
+      {
+        name: "celebrity_user_id",
+        type: "int",
+        notNull: true,
+        unique: false,
+        defaultValue: null,
+        comment: "",
+      },
+      {
+        name: "user",
+        type: "link",
+        link: { table: "Users" },
+        notNull: true,
+        unique: false,
+        defaultValue: null,
+        comment: '{"xata.link":"Users"}',
+      },
+      {
+        name: "xata_createdat",
+        type: "datetime",
+        notNull: true,
+        unique: false,
+        defaultValue: "now()",
+        comment: "",
+      },
+      {
+        name: "xata_id",
+        type: "text",
+        notNull: true,
+        unique: true,
+        defaultValue: "('rec_'::text || (xata_private.xid())::text)",
+        comment: "",
+      },
+      {
+        name: "xata_updatedat",
+        type: "datetime",
+        notNull: true,
+        unique: false,
+        defaultValue: "now()",
+        comment: "",
+      },
+      {
+        name: "xata_version",
+        type: "int",
+        notNull: true,
+        unique: false,
+        defaultValue: "0",
+        comment: "",
+      },
+    ],
+  },
+  {
+    name: "PublicFigures",
+    checkConstraints: {
+      PublicFigures_xata_id_length_xata_id: {
+        name: "PublicFigures_xata_id_length_xata_id",
+        columns: ["xata_id"],
+        definition: "CHECK ((length(xata_id) < 256))",
+      },
+    },
+    foreignKeys: {},
+    primaryKey: [],
+    uniqueConstraints: {
+      PublicFigures__pgroll_new_name_key: {
+        name: "PublicFigures__pgroll_new_name_key",
+        columns: ["name"],
+      },
+      _pgroll_new_PublicFigures_xata_id_key: {
+        name: "_pgroll_new_PublicFigures_xata_id_key",
+        columns: ["xata_id"],
+      },
+    },
+    columns: [
+      {
+        name: "celebrity_id",
+        type: "int",
+        notNull: true,
+        unique: false,
+        defaultValue: null,
+        comment: "",
+      },
+      {
+        name: "name",
+        type: "text",
+        notNull: true,
+        unique: true,
+        defaultValue: null,
+        comment: "",
+      },
+      {
+        name: "scores",
+        type: "json",
+        notNull: true,
+        unique: false,
+        defaultValue: null,
+        comment: "",
       },
       {
         name: "xata_createdat",
@@ -1853,6 +2022,12 @@ export type PaymentsRecord = Payments & XataRecord;
 export type PersonalizedAnswers = InferredTypes["PersonalizedAnswers"];
 export type PersonalizedAnswersRecord = PersonalizedAnswers & XataRecord;
 
+export type PublicFigurePerUser = InferredTypes["PublicFigurePerUser"];
+export type PublicFigurePerUserRecord = PublicFigurePerUser & XataRecord;
+
+export type PublicFigures = InferredTypes["PublicFigures"];
+export type PublicFiguresRecord = PublicFigures & XataRecord;
+
 export type Questions = InferredTypes["Questions"];
 export type QuestionsRecord = Questions & XataRecord;
 
@@ -1887,6 +2062,8 @@ export type DatabaseSchema = {
   InsightsPerUserCategory: InsightsPerUserCategoryRecord;
   Payments: PaymentsRecord;
   PersonalizedAnswers: PersonalizedAnswersRecord;
+  PublicFigurePerUser: PublicFigurePerUserRecord;
+  PublicFigures: PublicFiguresRecord;
   Questions: QuestionsRecord;
   Regions: RegionsRecord;
   StandardAnswers: StandardAnswersRecord;


### PR DESCRIPTION
This PR does the following:

- Add xata db migrations for `PublicFigure` and `PublicFigurePerUser` for #140

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced enhanced support for managing public figure profiles, enabling detailed tracking of public figures and their associated user data.
  - Expanded the data model with new fields to store additional public figure information, such as identifiers, names, and metrics.
  - Improved the overall data structure for a richer, more integrated experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->